### PR TITLE
Remove 【GoogleSignIn】 specified version

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files  = "ios/RNGoogleSignin/*.{h,m}"
   s.dependency "React"
-  s.dependency "GoogleSignIn", "~> 4.4.0"
+  s.dependency "GoogleSignIn"
 end


### PR DESCRIPTION
podspec默认使用最新版，主podfile没有使用GoogleSignIn，所以不需要指定